### PR TITLE
faster mulMonty

### DIFF
--- a/ocl/kernel2.cl
+++ b/ocl/kernel2.cl
@@ -38,7 +38,9 @@ INLINE uint _subMod(const uint lhs, const uint rhs, const uint p)
 // If lhs = x and rhs = y * 2^32 then r = x * y mod p.
 INLINE uint _mulMonty(const uint lhs, const uint rhs, const uint p, const uint q)
 {
-	const uint t_lo = lhs * rhs, t_hi = mul_hi(lhs, rhs);
+	const ulong prod = (ulong)lhs * rhs;
+	const uint t_lo = (uint)prod;
+	const uint t_hi = prod >> 32;
 	const uint mp = mul_hi(t_lo * q, p);
 	return _subMod(t_hi, mp, p);
 }
@@ -954,7 +956,7 @@ INLINE uint barrett(const ulong a, const uint b, const uint b_inv, const int b_s
 
 	const uint d = mul_hi((uint)(a >> b_s), b_inv), r = (uint)a - d * b;
 	const bool o = (r >= b);
-	*a_p = o ? d + 1 : d;
+	*a_p = d + (uint)o;
 	return o ? r - b : r;
 }
 

--- a/ocl/kernel3.cl
+++ b/ocl/kernel3.cl
@@ -33,7 +33,7 @@ INLINE bool uint96_is_greater(const uint96 x, const uint96 y) { return (x.s1 > y
 
 INLINE int96 int96_neg(const int96 x)
 {
-	const int c = (x.s0 != 0) ? 1 : 0;
+	const int c = x.s0 != 0;
 	int96 r; r.s0 = -x.s0; r.s1 = -x.s1 - c;
 	return r;
 }
@@ -115,7 +115,9 @@ INLINE uint _subMod(const uint lhs, const uint rhs, const uint p)
 // If lhs = x and rhs = y * 2^32 then r = x * y mod p.
 INLINE uint _mulMonty(const uint lhs, const uint rhs, const uint p, const uint q)
 {
-	const uint t_lo = lhs * rhs, t_hi = mul_hi(lhs, rhs);
+	const ulong prod = (ulong)lhs * rhs;
+	const uint t_lo = (uint)prod;
+	const uint t_hi = prod >> 32;
 	const uint mp = mul_hi(t_lo * q, p);
 	return _subMod(t_hi, mp, p);
 }
@@ -1241,7 +1243,7 @@ INLINE uint barrett(const ulong a, const uint b, const uint b_inv, const int b_s
 
 	const uint d = mul_hi((uint)(a >> b_s), b_inv), r = (uint)a - d * b;
 	const bool o = (r >= b);
-	*a_p = o ? d + 1 : d;
+	*a_p = d + (uint)o;
 	return o ? r - b : r;
 }
 

--- a/src/ocl/kernel2.h
+++ b/src/ocl/kernel2.h
@@ -50,7 +50,9 @@ static const char * const src_ocl_kernel2 = \
 "// If lhs = x and rhs = y * 2^32 then r = x * y mod p.\n" \
 "INLINE uint _mulMonty(const uint lhs, const uint rhs, const uint p, const uint q)\n" \
 "{\n" \
-"	const uint t_lo = lhs * rhs, t_hi = mul_hi(lhs, rhs);\n" \
+"	const ulong prod = (ulong)lhs * rhs;\n" \
+"	const uint t_lo = (uint)prod;\n" \
+"	const uint t_hi = prod >> 32;\n" \
 "	const uint mp = mul_hi(t_lo * q, p);\n" \
 "	return _subMod(t_hi, mp, p);\n" \
 "}\n" \
@@ -966,7 +968,7 @@ static const char * const src_ocl_kernel2 = \
 "\n" \
 "	const uint d = mul_hi((uint)(a >> b_s), b_inv), r = (uint)a - d * b;\n" \
 "	const bool o = (r >= b);\n" \
-"	*a_p = o ? d + 1 : d;\n" \
+"	*a_p = d + (uint)o;\n" \
 "	return o ? r - b : r;\n" \
 "}\n" \
 "\n" \

--- a/src/ocl/kernel3.h
+++ b/src/ocl/kernel3.h
@@ -45,7 +45,7 @@ static const char * const src_ocl_kernel3 = \
 "\n" \
 "INLINE int96 int96_neg(const int96 x)\n" \
 "{\n" \
-"	const int c = (x.s0 != 0) ? 1 : 0;\n" \
+"	const int c = x.s0 != 0;\n" \
 "	int96 r; r.s0 = -x.s0; r.s1 = -x.s1 - c;\n" \
 "	return r;\n" \
 "}\n" \
@@ -127,7 +127,9 @@ static const char * const src_ocl_kernel3 = \
 "// If lhs = x and rhs = y * 2^32 then r = x * y mod p.\n" \
 "INLINE uint _mulMonty(const uint lhs, const uint rhs, const uint p, const uint q)\n" \
 "{\n" \
-"	const uint t_lo = lhs * rhs, t_hi = mul_hi(lhs, rhs);\n" \
+"	const ulong prod = (ulong)lhs * rhs;\n" \
+"	const uint t_lo = (uint)prod;\n" \
+"	const uint t_hi = prod >> 32;\n" \
 "	const uint mp = mul_hi(t_lo * q, p);\n" \
 "	return _subMod(t_hi, mp, p);\n" \
 "}\n" \
@@ -1253,7 +1255,7 @@ static const char * const src_ocl_kernel3 = \
 "\n" \
 "	const uint d = mul_hi((uint)(a >> b_s), b_inv), r = (uint)a - d * b;\n" \
 "	const bool o = (r >= b);\n" \
-"	*a_p = o ? d + 1 : d;\n" \
+"	*a_p = d + (uint)o;\n" \
 "	return o ? r - b : r;\n" \
 "}\n" \
 "\n" \


### PR DESCRIPTION
about 5% faster on Radeon 7900 XTX

before
```
400000000^{2^16} + 1: 00:00:49, 0.0262 ms/bit, data size: 2.25 MB.
250000000^{2^17} + 1: 00:02:14, 0.0369 ms/bit, data size: 4.5 MB.
40000000^{2^18} + 1: 00:06:07, 0.0555 ms/bit, data size: 9 MB.
9000000^{2^19} + 1: 00:21:46, 0.108 ms/bit, data size: 18 MB.
3500000^{2^20} + 1: 01:18:42, 0.207 ms/bit, data size: 36 MB.
1500000^{2^21} + 1: 03:17:50, 0.276 ms/bit, data size: 48 MB.
400000^{2^22} + 1: 11:52:54, 0.548 ms/bit, data size: 96 MB.
1200000^{2^22} + 1: 12:52:49, 0.547 ms/bit, data size: 96 MB.
500000^{2^23} + 1: 51:10:24, 1.16 ms/bit, data size: 192 MB.
```

after
```
400000000^{2^16} + 1: 00:00:47, 0.0254 ms/bit, data size: 2.25 MB.
250000000^{2^17} + 1: 00:02:11, 0.036 ms/bit, data size: 4.5 MB.
40000000^{2^18} + 1: 00:05:46, 0.0523 ms/bit, data size: 9 MB.
9000000^{2^19} + 1: 00:20:52, 0.103 ms/bit, data size: 18 MB.
3500000^{2^20} + 1: 01:15:19, 0.198 ms/bit, data size: 36 MB.
1500000^{2^21} + 1: 03:11:20, 0.267 ms/bit, data size: 48 MB.
400000^{2^22} + 1: 11:30:24, 0.531 ms/bit, data size: 96 MB.
1200000^{2^22} + 1: 12:28:20, 0.53 ms/bit, data size: 96 MB.
500000^{2^23} + 1: 49:16:19, 1.12 ms/bit, data size: 192 MB.
```
